### PR TITLE
UPDATE: Add /api/simulate/<workbookId> endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "clsx": "^1.2.1",
         "eslint": "8.36.0",
         "eslint-config-next": "13.2.4",
+        "form-data": "^4.0.0",
         "http-proxy": "^1.18.1",
         "lucide-react": "^0.128.0",
         "next": "13.2.4",
@@ -1271,6 +1272,11 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/attr-accept": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
@@ -1424,6 +1430,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1541,6 +1558,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dir-glob": {
@@ -2278,6 +2303,19 @@
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -3081,6 +3119,25 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clsx": "^1.2.1",
     "eslint": "8.36.0",
     "eslint-config-next": "13.2.4",
+    "form-data": "^4.0.0",
     "http-proxy": "^1.18.1",
     "lucide-react": "^0.128.0",
     "next": "13.2.4",

--- a/src/pages/api/simulate/[workbookId].ts
+++ b/src/pages/api/simulate/[workbookId].ts
@@ -1,0 +1,65 @@
+import {
+  simulate,
+  CellValue,
+  RangeValue,
+  SimulateInputs,
+  SimulateOutputs,
+} from '@/lib/server/sheetsApi';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import z from 'zod';
+
+const CellValue: z.ZodType<CellValue> = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+const RangeValue: z.ZodType<RangeValue> = CellValue.array().array();
+
+// sheet name => cell or range reference => assignment
+const SimulateInputs: z.ZodType<SimulateInputs> = z.record(
+  z.string(),
+  z.record(z.string(), z.union([CellValue, RangeValue])),
+);
+
+// sheet name => list of cell or range references
+const SimulateOutputs: z.ZodType<SimulateOutputs> = z.record(z.string(), z.string().array());
+
+const Parameters = z.object({ inputs: SimulateInputs, outputs: SimulateOutputs });
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<{}>) {
+  const { workbookId } = req.query;
+  if (typeof workbookId !== 'string') {
+    res.status(404).send({ message: 'Invalid workbook ID.' });
+    return;
+  }
+
+  let parameters;
+  if (req.method === 'GET') {
+    const { inputs, outputs } = req.query;
+    if (typeof inputs !== 'string' || typeof outputs !== 'string') {
+      return res.status(400).send({
+        message:
+          'GET parameters are not compatible with schema. Error: inputs and outputs are required',
+      });
+    }
+    try {
+      parameters = {
+        inputs: SimulateInputs.parse(JSON.parse(inputs)),
+        outputs: SimulateOutputs.parse(JSON.parse(outputs)),
+      };
+    } catch (error) {
+      return res.status(400).send({
+        message: `GET parameters are not compatible with schema. Error: ${error}`,
+      });
+    }
+  } else if (req.method === 'POST') {
+    try {
+      parameters = Parameters.parse(req.body);
+    } catch (error) {
+      return res.status(400).send({
+        message: `POST parameters are not compatible with schema. Error: ${error}`,
+      });
+    }
+  } else {
+    return res.status(405).send({ message: 'Only GET and POST requests are allowed.' });
+  }
+
+  const result = await simulate({ workbookId, ...parameters });
+  res.status(200).json(result);
+}


### PR DESCRIPTION
TEST:
1. Build SureSheet locally ([readme](https://github.com/EqualTo-Software/SureSheet#readme)).
2. Go to http://localhost:3000/ and create a new workbook.
3. Confirm that `/api/simulate/<workbookId>` supports both GET and POST methods:

GET:

```
curl --location --globoff 'http://localhost:3000/api/simulate/<workbookId>?inputs={%22Sheet1%22%3A{%22A1%22%3A42}}&outputs={%22Sheet1%22%3A[%22A1%22]}'
```

POST:

```
curl --location 'http://localhost:3000/api/simulate/<workbookId>' \
--header 'Content-Type: application/json' \
--data '{
    "inputs": {"Sheet1": {"A1": 42, "A2:A2": [[84]]}},
    "outputs": {"Sheet1": ["A1", "A2", "A1:A2"]}
}'
```

