### PR TITLE
UPDATE: Allow CORS requests to /api/v1/simulate

### DIFF
--- a/src/pages/api/v1/simulate/[workbookId].ts
+++ b/src/pages/api/v1/simulate/[workbookId].ts
@@ -23,6 +23,12 @@ const SimulateOutputs: z.ZodType<SimulateOutputs> = z.record(z.string(), z.strin
 const Parameters = z.object({ inputs: SimulateInputs, outputs: SimulateOutputs });
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<{}>) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
   const { workbookId } = req.query;
   if (typeof workbookId !== 'string') {
     res.status(404).send({ message: 'Invalid workbook ID.' });


### PR DESCRIPTION
Testable locally, if you deploy on localhost, without the fix this should fail, when ran from console in another domain (eg. open equalto.com and then in console run this fetch):

```
fetch('http://localhost:3000/api/v1/simulate/test', {method: 'POST'})
```

With this fix, you should get 400 instead of CORS error, or if you supply correct data, it should return the JSON response.