### PR TITLE
UPDATE: Add SureSheet Collab API demo page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@mui/material": "^5.11.14",
         "@prisma/client": "^4.11.0",
         "@types/node": "18.15.7",
+        "@types/prismjs": "^1.26.0",
         "@types/react": "18.0.28",
         "@types/react-dom": "18.0.11",
         "clsx": "^1.2.1",
@@ -24,6 +25,7 @@
         "http-proxy": "^1.18.1",
         "lucide-react": "^0.128.0",
         "next": "13.2.4",
+        "prismjs": "^1.29.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-dropzone": "^14.2.3",
@@ -972,6 +974,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
+      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -3501,6 +3508,14 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "prisma generate && next build && prisma db push",
     "start": "next start -p $PORT",
-    "lint": "next lint"
+    "check-tsc": "tsc --noEmit",
+    "lint": "npm run check-tsc && next lint"
   },
   "dependencies": {
     "@emotion/react": "^11.10.6",
@@ -17,6 +18,7 @@
     "@mui/material": "^5.11.14",
     "@prisma/client": "^4.11.0",
     "@types/node": "18.15.7",
+    "@types/prismjs": "^1.26.0",
     "@types/react": "18.0.28",
     "@types/react-dom": "18.0.11",
     "clsx": "^1.2.1",
@@ -25,6 +27,7 @@
     "http-proxy": "^1.18.1",
     "lucide-react": "^0.128.0",
     "next": "13.2.4",
+    "prismjs": "^1.29.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-dropzone": "^14.2.3",

--- a/public/html/collab-demo.css
+++ b/public/html/collab-demo.css
@@ -1,0 +1,56 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
+
+body {
+  font-family: Inter;
+}
+
+h1 {
+  font-weight: 600;
+}
+
+.input-form label {
+  display: block;
+}
+
+.input-form label + label {
+  margin-top: 10px;
+}
+
+.input-form label input {
+  padding: 5px 10px;
+  background: #ffffff;
+  border: 1px solid #b4b7d1;
+  box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1);
+  border-radius: 5px;
+}
+
+.output {
+  transition: opacity 0.2s ease-in-out;
+}
+
+.output.loading {
+  opacity: 0.2;
+}
+
+.output table {
+  margin-top: 20px;
+  border-collapse: collapse;
+}
+
+.output table thead {
+  background: #f1f2f8;
+  font-weight: 600;
+  padding: 15px 10px;
+}
+
+.output table thead tr th {
+  border: 1px solid #dee0ef;
+}
+
+.output table tbody th,
+.output table tbody td {
+  padding: 10px;
+  font-weight: 400;
+  background: #ffffff;
+  border: 1px solid #dee0ef;
+}

--- a/public/html/collab-demo.html
+++ b/public/html/collab-demo.html
@@ -4,90 +4,32 @@
       type="text/javascript"
       src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"
     ></script>
-    <style type="text/css">
-      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
-
-      body {
-        font-family: Inter;
-      }
-
-      h1 {
-        font-weight: 600;
-      }
-
-      .input-form label {
-        display: block;
-      }
-
-      .input-form label + label {
-        margin-top: 10px;
-      }
-
-      .input-form label input {
-        padding: 5px 10px;
-        background: #ffffff;
-        border: 1px solid #b4b7d1;
-        box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1);
-        border-radius: 5px;
-      }
-
-      .output {
-        transition: opacity 0.2s ease-in-out;
-      }
-
-      .output.loading {
-        opacity: 0.2;
-      }
-
-      .output table {
-        margin-top: 20px;
-        border-collapse: collapse;
-      }
-
-      .output table thead {
-        background: #f1f2f8;
-        font-weight: 600;
-        padding: 15px 10px;
-      }
-
-      .output table thead tr th {
-        border: 1px solid #dee0ef;
-      }
-
-      .output table tbody th,
-      .output table tbody td {
-        padding: 10px;
-        font-weight: 400;
-        background: #ffffff;
-        border: 1px solid #dee0ef;
-      }
-    </style>
-  </head>
-  <body>
-    <h1>Inputs</h1>
-    <form class="input-form">
-      <label>
-        Initial investment amount:
-        <input name="initialInvestmentAmount" type="number" value="1000" step="0.01" />
-      </label>
-      <label>
-        Additional yearly contribution:
-        <input name="additionalYearlyContribution" type="number" value="100" step="0.01" />
-      </label>
-      <label>
-        Rate of return (%):
-        <input name="rateOfReturn" type="number" value="5" step="0.01" />
-      </label>
-    </form>
-
-    <div class="output">
-      <h1>Results</h1>
-      Capital at the end of term: <span class="capitalAtTheEnd">-</span>
-      <div class="details"></div>
-    </div>
-
+    <link rel="stylesheet" href="./collab-demo.css" />
     <script type="text/javascript">
       //<![CDATA[
+
+      /**
+       * Summary
+       * =======
+       * When the input controls change in the DOM, this code executes the /simulate API
+       * to determine the results from the Investment Growth Calculator with this new data.
+       *
+       * Details
+       * =======
+       * - onFormUpdate(): when the inputs in the DOM change, this event handler is called. It
+       *                   executes the /simulate API via a call to simulate()
+       * - updateDOM():    writes the result of the /simulate API to the DOM
+       */
+
+      document.addEventListener('load', () => {
+        onFormUpdate();
+        document.querySelector('.input-form').addEventListener(
+          'input',
+          _.debounce((event) => {
+            onFormUpdate();
+          }, 600),
+        );
+      });
 
       let lastRequestId = 0;
 
@@ -118,14 +60,6 @@
             }
           });
       }
-
-      onFormUpdate();
-      document.querySelector('.input-form').addEventListener(
-        'input',
-        _.debounce((event) => {
-          onFormUpdate();
-        }, 600),
-      );
 
       async function simulate(initialInvestmentAmount, additionalYearlyContribution, rateOfReturn) {
         // Suresheet: https://www.equalto.com/suresheet/view/0e1fbb42-1b69-49f1-aa69-e1d804f28b9c
@@ -250,5 +184,28 @@
 
       //]]>
     </script>
+  </head>
+  <body>
+    <h1>Inputs</h1>
+    <form class="input-form">
+      <label>
+        Initial investment amount:
+        <input name="initialInvestmentAmount" type="number" value="1000" step="0.01" />
+      </label>
+      <label>
+        Additional yearly contribution:
+        <input name="additionalYearlyContribution" type="number" value="100" step="0.01" />
+      </label>
+      <label>
+        Rate of return (%):
+        <input name="rateOfReturn" type="number" value="5" step="0.01" />
+      </label>
+    </form>
+
+    <div class="output">
+      <h1>Results</h1>
+      Capital at the end of term: <span class="capitalAtTheEnd">-</span>
+      <div class="details"></div>
+    </div>
   </body>
 </html>

--- a/public/html/collab-demo.html
+++ b/public/html/collab-demo.html
@@ -21,7 +21,13 @@
        * - updateDOM():    writes the result of the /simulate API to the DOM
        */
 
-      document.addEventListener('load', () => {
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+      } else {
+        init();
+      }
+
+      function init() {
         onFormUpdate();
         document.querySelector('.input-form').addEventListener(
           'input',
@@ -29,7 +35,7 @@
             onFormUpdate();
           }, 600),
         );
-      });
+      }
 
       let lastRequestId = 0;
 

--- a/public/html/collab-demo.html
+++ b/public/html/collab-demo.html
@@ -1,0 +1,254 @@
+<html>
+  <head>
+    <script
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"
+    ></script>
+    <style type="text/css">
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
+
+      body {
+        font-family: Inter;
+      }
+
+      h1 {
+        font-weight: 600;
+      }
+
+      .input-form label {
+        display: block;
+      }
+
+      .input-form label + label {
+        margin-top: 10px;
+      }
+
+      .input-form label input {
+        padding: 5px 10px;
+        background: #ffffff;
+        border: 1px solid #b4b7d1;
+        box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1);
+        border-radius: 5px;
+      }
+
+      .output {
+        transition: opacity 0.2s ease-in-out;
+      }
+
+      .output.loading {
+        opacity: 0.2;
+      }
+
+      .output table {
+        margin-top: 20px;
+        border-collapse: collapse;
+      }
+
+      .output table thead {
+        background: #f1f2f8;
+        font-weight: 600;
+        padding: 15px 10px;
+      }
+
+      .output table thead tr th {
+        border: 1px solid #dee0ef;
+      }
+
+      .output table tbody th,
+      .output table tbody td {
+        padding: 10px;
+        font-weight: 400;
+        background: #ffffff;
+        border: 1px solid #dee0ef;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Inputs</h1>
+    <form class="input-form">
+      <label>
+        Initial investment amount:
+        <input name="initialInvestmentAmount" type="number" value="1000" step="0.01" />
+      </label>
+      <label>
+        Additional yearly contribution:
+        <input name="additionalYearlyContribution" type="number" value="100" step="0.01" />
+      </label>
+      <label>
+        Rate of return (%):
+        <input name="rateOfReturn" type="number" value="5" step="0.01" />
+      </label>
+    </form>
+
+    <div class="output">
+      <h1>Results</h1>
+      Capital at the end of term: <span class="capitalAtTheEnd">-</span>
+      <div class="details"></div>
+    </div>
+
+    <script type="text/javascript">
+      //<![CDATA[
+
+      let lastRequestId = 0;
+
+      function onFormUpdate() {
+        const requestId = lastRequestId + 1;
+        lastRequestId = requestId;
+
+        const inputs = readInputs();
+
+        startLoading();
+
+        simulate(
+          inputs.initialInvestmentAmount,
+          inputs.additionalYearlyContribution,
+          inputs.rateOfReturn,
+        )
+          .then(({ capitalAtTheEnd, details }) => {
+            if (lastRequestId === requestId) {
+              updateDOM(capitalAtTheEnd, details);
+            }
+          })
+          .catch((error) => {
+            console.error('Could not get simulation results', error);
+          })
+          .finally(() => {
+            if (lastRequestId === requestId) {
+              stopLoading();
+            }
+          });
+      }
+
+      onFormUpdate();
+      document.querySelector('.input-form').addEventListener(
+        'input',
+        _.debounce((event) => {
+          onFormUpdate();
+        }, 600),
+      );
+
+      async function simulate(initialInvestmentAmount, additionalYearlyContribution, rateOfReturn) {
+        // Suresheet: https://www.equalto.com/suresheet/view/0e1fbb42-1b69-49f1-aa69-e1d804f28b9c
+        const workbookId = '0e1fbb42-1b69-49f1-aa69-e1d804f28b9c';
+        const simulateUrl = `https://www.equalto.com/suresheet/api/v1/simulate/${workbookId}`;
+
+        const sheetName = 'Investment return';
+        const detailsRange = 'B20:F41';
+
+        const response = await fetch(simulateUrl, {
+          method: 'POST',
+          body: JSON.stringify({
+            inputs: {
+              [sheetName]: {
+                C6: initialInvestmentAmount,
+                C7: additionalYearlyContribution,
+                C8: rateOfReturn,
+              },
+            },
+            outputs: {
+              [sheetName]: ['C13', detailsRange],
+            },
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+        const responseJson = await response.json();
+        const sheet = responseJson[sheetName];
+        return {
+          capitalAtTheEnd: sheet.C13,
+          details: sheet[detailsRange],
+        };
+      }
+
+      function readInputs() {
+        const initialInvestmentInput = document.querySelector(
+          'input[name=initialInvestmentAmount]',
+        );
+        const additionalYearContributionInput = document.querySelector(
+          'input[name=additionalYearlyContribution]',
+        );
+        const rateOfReturnInput = document.querySelector('input[name=rateOfReturn]');
+
+        const initialInvestmentAmount = parseFloat(initialInvestmentInput.value);
+        const additionalYearlyContribution = parseFloat(additionalYearContributionInput.value);
+        const rateOfReturn = parseFloat(rateOfReturnInput.value) / 100.0;
+
+        return {
+          initialInvestmentAmount,
+          additionalYearlyContribution,
+          rateOfReturn,
+        };
+      }
+
+      function startLoading() {
+        const output = document.querySelector('.output');
+        output.classList.add('loading');
+      }
+
+      function stopLoading() {
+        const output = document.querySelector('.output');
+        output.classList.remove('loading');
+      }
+
+      function updateDOM(capitalAtTheEnd, details) {
+        const usdNumberFormat = new Intl.NumberFormat(navigator.language, {
+          style: 'currency',
+          currency: 'USD',
+          currencyDisplay: 'narrowSymbol',
+        });
+
+        const capitalSlot = document.querySelector('.output .capitalAtTheEnd');
+        capitalSlot.innerText = usdNumberFormat.format(capitalAtTheEnd);
+
+        const detailsSlot = document.querySelector('.output .details');
+        if (details.length > 0) {
+          const table = document.createElement('table');
+          const tableHead = document.createElement('thead');
+          const tableHeadRow = document.createElement('tr');
+          const tableBody = document.createElement('tbody');
+
+          const [headers, ...data] = details;
+
+          for (const header of headers) {
+            const cell = document.createElement('th');
+            cell.innerText = header;
+            tableHeadRow.appendChild(cell);
+          }
+
+          for (const dataRow of data) {
+            if (dataRow.every((dataCell) => dataCell == null)) {
+              continue;
+            }
+            const row = document.createElement('tr');
+            const [year, ...currencyDataCells] = dataRow;
+
+            const th = document.createElement('th');
+            th.innerText = year;
+            row.appendChild(th);
+
+            for (const currencyCell of currencyDataCells) {
+              const cell = document.createElement('td');
+              if (currencyCell !== null) {
+                cell.innerText = usdNumberFormat.format(currencyCell);
+              }
+              row.appendChild(cell);
+            }
+
+            tableBody.appendChild(row);
+          }
+
+          tableHead.appendChild(tableHeadRow);
+          table.appendChild(tableHead);
+          table.appendChild(tableBody);
+
+          detailsSlot.replaceChildren(table);
+        } else {
+          detailsSlot.replaceChildren();
+        }
+      }
+
+      //]]>
+    </script>
+  </body>
+</html>

--- a/src/components/infoBar.module.css
+++ b/src/components/infoBar.module.css
@@ -1,0 +1,53 @@
+.infoBar {
+  background: #5879f0;
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 15px;
+  color: #f1f2f8;
+  padding: 5px 10px;
+
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.infoBar.rounded {
+  border-radius: 5px;
+}
+
+.infoBar.centered {
+  text-align: center;
+}
+
+.infoBar .actions {
+  white-space: nowrap;
+}
+
+.infoBar .actions .toggleUI {
+  cursor: pointer;
+}
+
+.infoBar .actions * + *::before {
+  content: '';
+  display: inline-block;
+  height: 10px;
+  width: 1px;
+  margin: 0 10px;
+  background: #dee0ef;
+  opacity: 0.2;
+  border-radius: 11px;
+  vertical-align: middle;
+}
+
+.infoBar .actions .githubLink {
+  display: inline-block;
+}
+
+.infoBar a:link,
+.infoBar a:visited,
+.infoBar a:hover,
+.infoBar a:active {
+  color: #f1f2f8;
+  font-weight: 500;
+  text-underline-offset: 3px;
+}

--- a/src/components/infoBar.tsx
+++ b/src/components/infoBar.tsx
@@ -1,0 +1,54 @@
+import { ArrowUpRight } from 'lucide-react';
+import styles from './infoBar.module.css';
+import clsx from 'clsx';
+
+export function InfoBar(
+  properties: {
+    className?: string;
+    rounded?: boolean;
+    showGithubLink?: boolean;
+  } & (
+    | {
+        canToggleMenuBar: true;
+        isMenuBarVisible: boolean;
+        onToggle: () => void;
+      }
+    | {
+        canToggleMenuBar?: false;
+      }
+  ),
+) {
+  return (
+    <div
+      className={clsx(properties.className, styles.infoBar, properties.rounded && styles.rounded)}
+    >
+      <span>
+        {'Powered by '}
+        <a href="https://www.equalto.com/sheets" target="_blank">
+          EqualTo Sheets
+        </a>
+        : Spreadsheets as a Service for developers.
+      </span>
+      <div className={clsx(styles.actions)}>
+        {properties.canToggleMenuBar && (
+          <span
+            className={clsx(styles.toggleUI)}
+            role="button"
+            onClick={() => properties.onToggle()}
+          >
+            {properties.isMenuBarVisible ? 'Hide UI' : 'Show UI'}
+          </span>
+        )}
+        {properties.showGithubLink && (
+          <a
+            className={clsx(styles.githubLink)}
+            href="https://www.github.com/EqualTo-Software/SureSheet"
+            target="_blank"
+          >
+            GitHub repo <ArrowUpRight size={9} />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/logoStack.tsx
+++ b/src/components/logoStack.tsx
@@ -1,0 +1,26 @@
+import { Stack } from '@mui/system';
+import Image from 'next/image';
+import styles from './mainLayout.module.css';
+import getConfig from 'next/config';
+
+const { publicRuntimeConfig } = getConfig();
+
+export function LogoStack(properties: { siteName: string }) {
+  return (
+    <Stack direction="row" alignItems="center" spacing={2}>
+      <a className={styles.logoLink} href="https://www.equalto.com/" target="_blank">
+        <Image
+          priority
+          src={`${publicRuntimeConfig.basePath}/images/equalto.svg`}
+          width={32}
+          height={32}
+          alt="EqualTo Logo"
+        />
+      </a>
+      <Stack direction="row" alignItems="center" spacing={0}>
+        <code className={styles.siteName}>{properties.siteName}</code>
+        <span className={styles.betaTag}>Beta</span>
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/components/mainLayout.module.css
+++ b/src/components/mainLayout.module.css
@@ -8,57 +8,6 @@
   padding: 10px 10px 0 10px;
 }
 
-.infoBar {
-  border-radius: 5px;
-  background: #5879f0;
-  font-family: var(--font-body);
-  font-size: 13px;
-  line-height: 15px;
-  color: #f1f2f8;
-  padding: 5px 10px;
-
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-}
-
-.infoBar.centered {
-  text-align: center;
-}
-
-.infoBar .actions {
-  white-space: nowrap;
-}
-
-.infoBar .actions .toggleUI {
-  cursor: pointer;
-}
-
-.infoBar .actions * + *::before {
-  content: '';
-  display: inline-block;
-  height: 10px;
-  width: 1px;
-  margin: 0 10px;
-  background: #dee0ef;
-  opacity: 0.2;
-  border-radius: 11px;
-  vertical-align: middle;
-}
-
-.infoBar .actions .githubLink {
-  display: inline-block;
-}
-
-.infoBar a:link,
-.infoBar a:visited,
-.infoBar a:hover,
-.infoBar a:active {
-  color: #f1f2f8;
-  font-weight: 500;
-  text-underline-offset: 3px;
-}
-
 .menuBar {
   padding: 10px 10px 0 10px;
 }

--- a/src/components/mainLayout.tsx
+++ b/src/components/mainLayout.tsx
@@ -1,13 +1,10 @@
 import { Stack } from '@mui/system';
-import { ArrowUpRight } from 'lucide-react';
-import getConfig from 'next/config';
-import Image from 'next/image';
 import { PropsWithChildren, useMemo, useState } from 'react';
 import styles from './mainLayout.module.css';
 import { ToolbarContext, ToolbarContextValue } from './toolbar';
 import clsx from 'clsx';
-
-const { publicRuntimeConfig } = getConfig();
+import { InfoBar } from './infoBar';
+import { LogoStack } from './logoStack';
 
 export default function MainLayout(
   properties: PropsWithChildren<{
@@ -26,9 +23,11 @@ export default function MainLayout(
     <div className={styles.layout}>
       <div className={styles.infoBarContainer}>
         {!canHideMenuBar ? (
-          <InfoBar />
+          <InfoBar rounded showGithubLink />
         ) : (
           <InfoBar
+            rounded
+            showGithubLink
             canToggleMenuBar
             onToggle={() => setMenuBarVisible((previous) => !previous)}
             isMenuBarVisible={isMenuBarVisible}
@@ -37,7 +36,7 @@ export default function MainLayout(
       </div>
       <div className={clsx(styles.menuBar, !isMenuBarVisible && styles.hidden)}>
         <Stack direction="row" justifyContent="space-between">
-          <LogoStack />
+          <LogoStack siteName="SureSheet" />
           <div style={{ flex: 1 }} ref={(ref) => setToolbarNode(ref)} />
         </Stack>
       </div>
@@ -45,67 +44,5 @@ export default function MainLayout(
         <ToolbarContext.Provider value={toolbarContext}>{children}</ToolbarContext.Provider>
       </div>
     </div>
-  );
-}
-
-export function InfoBar(
-  properties:
-    | {
-        canToggleMenuBar: true;
-        isMenuBarVisible: boolean;
-        onToggle: () => void;
-      }
-    | {
-        canToggleMenuBar?: false;
-      },
-) {
-  return (
-    <div className={styles.infoBar}>
-        <span>
-          {'Powered by '}
-          <a href="https://www.equalto.com/sheets" target="_blank">
-            EqualTo Sheets
-          </a>
-          : Spreadsheets as a Service for developers.
-        </span>
-        <div className={clsx(styles.actions)}>
-          {properties.canToggleMenuBar && (
-            <span
-              className={clsx(styles.toggleUI)}
-              role="button"
-              onClick={() => properties.onToggle()}
-            >
-              {properties.isMenuBarVisible ? 'Hide UI' : 'Show UI'}
-            </span>
-          )}
-          <a
-            className={clsx(styles.githubLink)}
-            href="https://www.github.com/EqualTo-Software/SureSheet"
-            target="_blank"
-          >
-            GitHub repo <ArrowUpRight size={9} />
-          </a>
-        </div>
-    </div>
-  );
-}
-
-export function LogoStack() {
-  return (
-    <Stack direction="row" alignItems="center" spacing={2}>
-      <a className={styles.logoLink} href="https://www.equalto.com/" target="_blank">
-        <Image
-          priority
-          src={`${publicRuntimeConfig.basePath}/images/equalto.svg`}
-          width={32}
-          height={32}
-          alt="EqualTo Logo"
-        />
-      </a>
-      <Stack direction="row" alignItems="center" spacing={0}>
-        <code className={styles.siteName}>SureSheet</code>
-        <span className={styles.betaTag}>Beta</span>
-      </Stack>
-    </Stack>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import { ToastProvider } from '@/components/toastProvider';
 import '@/styles/globals.css';
+import '@/styles/dracula-prism.css';
 import '@fontsource/fira-mono/400.css';
 import '@fontsource/inter/400.css';
 import '@fontsource/inter/500.css';
@@ -13,6 +14,7 @@ const theme = createTheme({
   spacing: 5,
   palette: {
     secondary: { main: '#21243A' },
+    info: { main: '#4E5161' },
   },
   typography: {
     fontFamily: 'Inter',

--- a/src/pages/collab-api.module.css
+++ b/src/pages/collab-api.module.css
@@ -1,0 +1,149 @@
+.grid {
+  display: grid;
+  width: 100%;
+  height: 100%;
+}
+
+@media screen and (min-width: 800px) {
+  .grid {
+    grid-template-areas:
+      'info-bar info-bar'
+      'menu-bar menu-bar'
+      'left right'
+      'footer footer';
+    grid-template-columns: 50% 50%;
+  }
+}
+
+@media screen and (max-width: 799px) {
+  .grid {
+    grid-template-areas:
+      'info-bar '
+      'menu-bar'
+      'left'
+      'right'
+      'footer';
+    grid-template-rows: min-content min-content 1fr 1fr min-content;
+  }
+}
+
+.infoBar {
+  grid-area: info-bar;
+}
+
+.menuBar {
+  grid-area: menu-bar;
+  background: linear-gradient(180deg, #292c42 0%, #1f2236 100%);
+  padding: 10px;
+}
+
+.leftPanel {
+  grid-area: left;
+  overflow: auto;
+  background: rgb(33, 36, 58);
+  color: #dee0ef;
+  padding: 10px;
+}
+
+.welcomeCopy {
+  margin-bottom: 20px;
+  padding: 15px;
+  border: 1px solid #34374c;
+  color: #dee0ef;
+  border-radius: 10px;
+}
+
+.welcomeCopy h1,
+.welcomeCopy p {
+  font-size: 13px;
+  line-height: 16px;
+}
+
+.welcomeCopy ol li + li {
+  margin-top: 10px;
+}
+
+.welcomeCopy h1 {
+  font-weight: 600;
+}
+
+.welcomeCopy a:link,
+.welcomeCopy a:visited,
+.welcomeCopy a:hover,
+.welcomeCopy a:active {
+  color: #5879f0;
+  text-decoration: none;
+}
+
+.infoIcon {
+  color: #5f6989;
+}
+
+.fiddleLink:link,
+.fiddleLink:visited,
+.fiddleLink:hover,
+.fiddleLink a:active {
+  padding: 5px 10px;
+  gap: 5px;
+  background: #565972;
+  border-radius: 33px;
+  color: #ffffff;
+  text-decoration: none;
+}
+
+.fiddleLink > svg {
+  margin-left: 2px;
+  margin-bottom: -1px;
+}
+
+.leftPanel .divider {
+  height: 1px;
+  width: 100%;
+  background: rgba(84, 89, 113, 0.3);
+  margin: 20px 0;
+}
+
+.leftPanel pre {
+  margin-bottom: 10px;
+}
+
+.demoIframe {
+  grid-area: right;
+  width: 100%;
+  height: 100%;
+}
+
+.footer {
+  grid-area: footer;
+  background: linear-gradient(180deg, #292c42 0%, #1f2236 100%);
+  color: #8b8fad;
+  font-size: 9px;
+  padding: 5px;
+}
+
+.footer a:link,
+.footer a:visited,
+.footer a:hover,
+.footer a:active {
+  color: #5879f0;
+  text-decoration: none;
+}
+
+.footer .divider {
+  border-left: 1px solid #5f6989;
+  height: 8px;
+}
+
+@media screen and (max-width: 799px) {
+  .menuBar :global(.MuiButtonBase-root) {
+    min-width: min-content;
+  }
+
+  .menuBar :global(.MuiButtonBase-root) :global(.MuiButton-startIcon) {
+    margin-right: 0px;
+  }
+
+  .wideOnly {
+    display: none;
+  }
+}

--- a/src/pages/collab-api.module.css
+++ b/src/pages/collab-api.module.css
@@ -75,8 +75,21 @@
   text-decoration: none;
 }
 
-.infoIcon {
-  color: #5f6989;
+.codeContainer {
+  position: relative;
+}
+
+.fiddleLinkTrack {
+  position: absolute;
+  top: 5px;
+  bottom: 5px;
+  right: 5px;
+}
+
+.fiddleLink {
+  display: inline-block;
+  position: sticky;
+  top: 0;
 }
 
 .fiddleLink:link,

--- a/src/pages/collab-api.tsx
+++ b/src/pages/collab-api.tsx
@@ -1,0 +1,126 @@
+import { InfoBar } from '@/components/infoBar';
+import { GetStaticProps } from 'next';
+import styles from './collab-api.module.css';
+import { LogoStack } from '@/components/logoStack';
+import { Button, Stack } from '@mui/material';
+import { ArrowUpRight, Book, Github, Info } from 'lucide-react';
+import { readFileSync } from 'fs';
+import path from 'path';
+import getConfig from 'next/config';
+import Prism from 'prismjs';
+
+const { publicRuntimeConfig } = getConfig();
+
+export const getStaticProps: GetStaticProps = async () => {
+  const htmlPath = path.join(process.cwd(), 'public', 'html', 'collab-demo.html');
+  const demoHtml = readFileSync(htmlPath, 'utf-8');
+
+  const highlighted = Prism.highlight(demoHtml, Prism.languages.html, 'html');
+
+  return {
+    props: {
+      demoHtml: highlighted,
+    },
+  };
+};
+
+export default function CollabApi(properties: { demoHtml: string }) {
+  return (
+    <div className={styles.grid}>
+      <InfoBar className={styles.infoBar} />
+      <Stack
+        className={styles.menuBar}
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+      >
+        <LogoStack siteName="SureSheet {Collab API}" />
+        <Stack direction="row" spacing={2}>
+          <Button
+            type="button"
+            variant="contained"
+            color="info"
+            href="https://suresheet-docs.equalto.com/"
+            target="_blank"
+            startIcon={<Book />}
+            title="API docs"
+          >
+            <span className={styles.wideOnly}>API docs</span>
+          </Button>
+          <Button
+            type="button"
+            variant="contained"
+            color="info"
+            href="https://github.com/EqualTo-Software/SureSheet"
+            target="_blank"
+            startIcon={<Github />}
+            title="GitHub"
+          >
+            <span className={styles.wideOnly}>GitHub</span>
+          </Button>
+        </Stack>
+      </Stack>
+      <div className={styles.leftPanel}>
+        <WelcomeCopy />
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Stack direction="row" alignItems="center" spacing={2}>
+            <Info className={styles.infoIcon} size={14} fontSize={14} />
+            <span>This snippet is read-only.</span>
+          </Stack>
+          <a className={styles.fiddleLink} href="https://jsfiddle.net/471hcjsm/1/" target="_blank">
+            Edit in JsFiddle
+            <ArrowUpRight size={14} fontSize={14} />
+          </a>
+        </Stack>
+        <div className={styles.divider} />
+        <pre className="language-html" dangerouslySetInnerHTML={{ __html: properties.demoHtml }} />
+      </div>
+      <iframe
+        className={styles.demoIframe}
+        frameBorder="0"
+        src={`${publicRuntimeConfig.basePath}/html/collab-demo.html`}
+      ></iframe>
+      <footer className={styles.footer}>
+        <Stack direction="row" justifyContent="center" alignItems="center" spacing={1}>
+          <div>Made in Berlin and Warsaw by the EqualTo team</div>
+          <div className={styles.divider} />
+          <a href="https://www.equalto.com/" target="_blank">
+            equalto.com
+          </a>
+        </Stack>
+      </footer>
+    </div>
+  );
+}
+
+function WelcomeCopy() {
+  return (
+    <div className={styles.welcomeCopy}>
+      <h1>Welcome to SureSheet Collab API!</h1>
+      <p>
+        The easiest way for developers to collaborate with business users via spreadsheets. The demo
+        below covers this scenario:
+      </p>
+      <ol>
+        <li>
+          Business user creates a simple{' '}
+          <a
+            href="https://www.equalto.com/suresheet/view/0e1fbb42-1b69-49f1-aa69-e1d804f28b9c"
+            target="_blank"
+          >
+            financial calculator workbook
+          </a>
+          , sharing the URL with the developer.
+        </li>
+        <li>
+          Developer builds a simple web app, which sends inputs to the financial model and displays
+          the results using the Simulation API.
+        </li>
+      </ol>
+      <p>
+        Note that the workbook accessed via the URL is immutable, so it’s “safe” for a developer to
+        integrate against.
+      </p>
+    </div>
+  );
+}

--- a/src/pages/collab-api.tsx
+++ b/src/pages/collab-api.tsx
@@ -3,7 +3,7 @@ import { GetStaticProps } from 'next';
 import styles from './collab-api.module.css';
 import { LogoStack } from '@/components/logoStack';
 import { Button, Stack } from '@mui/material';
-import { ArrowUpRight, Book, Github, Info } from 'lucide-react';
+import { ArrowUpRight, Book, Github } from 'lucide-react';
 import { readFileSync } from 'fs';
 import path from 'path';
 import getConfig from 'next/config';
@@ -62,18 +62,22 @@ export default function CollabApi(properties: { demoHtml: string }) {
       </Stack>
       <div className={styles.leftPanel}>
         <WelcomeCopy />
-        <Stack direction="row" justifyContent="space-between" alignItems="center">
-          <Stack direction="row" alignItems="center" spacing={2}>
-            <Info className={styles.infoIcon} size={14} fontSize={14} />
-            <span>This snippet is read-only.</span>
-          </Stack>
-          <a className={styles.fiddleLink} href="https://jsfiddle.net/471hcjsm/1/" target="_blank">
-            Edit in JsFiddle
-            <ArrowUpRight size={14} fontSize={14} />
-          </a>
-        </Stack>
-        <div className={styles.divider} />
-        <pre className="language-html" dangerouslySetInnerHTML={{ __html: properties.demoHtml }} />
+        <div className={styles.codeContainer}>
+          <div className={styles.fiddleLinkTrack}>
+            <a
+              className={styles.fiddleLink}
+              href="https://jsfiddle.net/471hcjsm/1/"
+              target="_blank"
+            >
+              Edit in JSFiddle
+              <ArrowUpRight size={14} fontSize={14} />
+            </a>
+          </div>
+          <pre
+            className="language-html"
+            dangerouslySetInnerHTML={{ __html: properties.demoHtml }}
+          />
+        </div>
       </div>
       <iframe
         className={styles.demoIframe}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,9 @@ import { useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import Image from 'next/image';
 import styles from './index.module.css';
-import MainLayout, { InfoBar, LogoStack } from '@/components/mainLayout';
+import MainLayout from '@/components/mainLayout';
+import { LogoStack } from '@/components/logoStack';
+import { InfoBar } from '@/components/infoBar';
 
 const { publicRuntimeConfig } = getConfig();
 
@@ -85,10 +87,10 @@ function NewWorkbookChoice(properties: { setWorkbookId: (workbookId: string) => 
 
   return (
     <div className={styles.newWorkbookLayout}>
-      <InfoBar />
+      <InfoBar rounded showGithubLink />
       <div className={styles.newWorkbookContainer}>
         <Paper className={styles.newWorkbookPaper}>
-          <LogoStack />
+          <LogoStack siteName="SureSheet" />
           <div className={styles.newWorkbookSection}>
             <Typography>
               A <b>SureSheet</b> is a spreadsheet that always {'"'}resets{'"'} when it{"'"}s

--- a/src/styles/dracula-prism.css
+++ b/src/styles/dracula-prism.css
@@ -1,0 +1,589 @@
+/* PrismJS 1.14.0
+http://prismjs.com/download.html#themes=prism&languages=markup+css+clike+javascript+abap+actionscript+ada+apacheconf+apl+applescript+c+arff+asciidoc+asm6502+aspnet+autohotkey+autoit+bash+basic+batch+bison+brainfuck+bro+cpp+csharp+arduino+coffeescript+clojure+ruby+csp+css-extras+d+dart+diff+django+docker+eiffel+elixir+elm+markup-templating+erlang+fsharp+flow+fortran+gedcom+gherkin+git+glsl+go+graphql+groovy+haml+handlebars+haskell+haxe+http+hpkp+hsts+ichigojam+icon+inform7+ini+io+j+java+jolie+json+julia+keyman+kotlin+latex+less+liquid+lisp+livescript+lolcode+lua+makefile+markdown+erb+matlab+mel+mizar+monkey+n4js+nasm+nginx+nim+nix+nsis+objectivec+ocaml+opencl+oz+parigp+parser+pascal+perl+php+php-extras+sql+powershell+processing+prolog+properties+protobuf+pug+puppet+pure+python+q+qore+r+jsx+typescript+renpy+reason+rest+rip+roboconf+crystal+rust+sas+sass+scss+scala+scheme+smalltalk+smarty+plsql+soy+stylus+swift+tcl+textile+twig+tsx+vbnet+velocity+verilog+vhdl+vim+visual-basic+wasm+wiki+xeora+xojo+yaml&plugins=line-numbers+toolbar+show-language */
+/**
+ * prism.js default theme for JavaScript, CSS and HTML
+ * Based on dabblet (http://dabblet.com)
+ * @author Lea Verou
+ */
+
+/*
+* Dracula Theme for Prism.JS
+*
+* @author Gustavo Costa
+* e-mail: gusbemacbe@gmail.com
+*
+* @contributor Jon Leopard
+* e-mail: jonlprd@gmail.com
+*
+* @license MIT 2016-2020
+*/
+
+/* Scrollbars */
+
+:root
+{
+  --background: #282A36;
+  --comment:    #6272A4;
+  --foreground: #F8F8F2;
+  --selection:  #44475A;
+
+  --cyan:       #8BE9FD;
+  --green:      #50FA7B;
+  --orange:     #FFB86C;
+  --pink:       #FF79C6;
+  --purple:     #BD93F9;
+  --red:        #FF5555;
+  --yellow:     #F1FA8C;
+
+  /* Transparency */
+
+  /** 30% of transparency **/
+  --background-30: #282A3633;
+  --comment-30:    #6272A433;
+  --foreground-30: #F8F8F233;
+  --selection-30:  #44475A33;
+
+  --cyan-30:       #8BE9FD33;
+  --green-30:      #50FA7B33;
+  --orange-30:     #FFB86C33;
+  --pink-30:       #FF79C633;
+  --purple-30:     #BD93F933;
+  --red-30:        #FF555533;
+  --yellow-30:     #F1FA8C33;
+
+  /** 40% of transparency **/
+  --background-40: #282A3666;
+  --comment-40:    #6272A466;
+  --foreground-40: #F8F8F266;
+  --selection-40:  #44475A66;
+
+  --cyan-40:       #8BE9FD66;
+  --green-40:      #50FA7B66;
+  --orange-40:     #FFB86C66;
+  --pink-40:       #FF79C666;
+  --purple-40:     #BD93F966;
+  --red-40:        #FF555566;
+  --yellow-40:     #F1FA8C66;
+}
+
+/* (EqualTo) Removed scrollbar styles */
+/*
+pre::-webkit-scrollbar
+{
+  width: 14px;
+}
+
+pre::-webkit-scrollbar-track 
+{
+  background-color: var(--comment);
+  border-radius: 0px;
+}
+
+pre::-webkit-scrollbar-thumb 
+{
+  background-color: var(--purple);
+  border-radius: 0px;
+}
+*/
+
+/* Selection */
+
+pre[class*="language-"]::-moz-selection,
+pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection,
+code[class*="language-"] ::-moz-selection 
+{
+  text-shadow: none;
+  background-color: var(--selection);
+}
+
+pre[class*="language-"]::selection,
+pre[class*="language-"] ::selection,
+code[class*="language-"]::selection,
+code[class*="language-"] ::selection 
+{
+  text-shadow: none;
+  background-color: var(--selection);
+}
+
+/* Line numbers */
+
+pre.line-numbers 
+{
+  position: relative;
+  padding-left: 3.8em;
+  counter-reset: linenumber;
+}
+
+pre.line-numbers > code 
+{
+  position: relative;
+  white-space: inherit;
+}
+
+.line-numbers .line-numbers-rows 
+{
+  position: absolute;
+  pointer-events: none;
+  top: 0;
+  font-size: 100%;
+  left: -3.8em;
+  width: 3em; /* works for line-numbers below 1000 lines */
+  letter-spacing: -1px;
+  border-right: 1px solid #999;
+
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.line-numbers-rows > span 
+{
+  pointer-events: none;
+  display: block;
+  counter-increment: linenumber;
+}
+
+.line-numbers-rows > span:before 
+{
+  content: counter(linenumber);
+  color: #999;
+  display: block;
+  padding-right: 0.8em;
+  text-align: right;
+}
+
+/* Toolbar for copying */
+
+div.code-toolbar 
+{
+  position: relative;
+}
+
+div.code-toolbar > .toolbar 
+{
+  position: absolute;
+  top: 0.3em;
+  right: 0.2em;
+  transition: opacity 0.3s ease-in-out;
+  opacity: 0;
+}
+
+div.code-toolbar:hover > .toolbar 
+{
+  opacity: 1;
+}
+
+div.code-toolbar > .toolbar .toolbar-item 
+{
+  display: inline-block;
+  padding-right: 20px;
+}
+
+div.code-toolbar > .toolbar a 
+{
+  cursor: pointer;
+}
+
+div.code-toolbar > .toolbar button 
+{
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  padding: 0;
+  -webkit-user-select: none; /* for button */
+  -moz-user-select: none;
+  -ms-user-select: none;
+}
+
+div.code-toolbar > .toolbar a,
+div.code-toolbar > .toolbar button,
+div.code-toolbar > .toolbar span 
+{
+  color: var(--foreground);
+  font-size: 0.8em;
+  padding: 0.5em;
+  background: var(--comment);
+  border-radius: 0.5em;
+}
+
+div.code-toolbar > .toolbar a:hover,
+div.code-toolbar > .toolbar a:focus,
+div.code-toolbar > .toolbar button:hover,
+div.code-toolbar > .toolbar button:focus,
+div.code-toolbar > .toolbar span:hover,
+div.code-toolbar > .toolbar span:focus 
+{
+  color: inherit;
+  text-decoration: none;
+  background-color: var(--green);
+}
+
+/* Remove text shadow for printing */
+
+@media print 
+{
+  code[class*="language-"],
+  pre[class*="language-"] 
+  {
+    text-shadow: none;
+  }
+}
+
+code[class*="language-"],
+pre[class*="language-"] 
+{
+  color: var(--foreground);
+  background: var(--background);
+  text-shadow: none;
+  /* (EqualTo) Added JetBrains Mono to font stack. */
+  font-family: "JetBrains Mono", PT Mono, Consolas, Monaco, "Andale Mono",
+    "Ubuntu Mono", monospace;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+/* Code blocks */
+
+pre[class*="language-"] 
+{
+  background: var(--background);
+  border-radius: 0.5em;
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+  height: auto;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] 
+{
+  background: var(--background);
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] 
+{
+  padding: 4px 7px;
+  border-radius: 0.3em;
+  white-space: normal;
+}
+
+/* Code box limit */
+
+.limit-300
+{
+  height: 300px !important;
+}
+
+.limit-300
+{
+  height: 400px !important;
+}
+
+.limit-500
+{
+  height: 500px !important;
+}
+
+.limit-600
+{
+  height: 600px !important;
+}
+
+.limit-700
+{
+  height: 700px !important;
+}
+
+.limit-800
+{
+  height: 800px !important;
+}
+
+.language-css
+{
+  color: var(--purple);
+}
+
+.token 
+{
+  color: var(--pink);
+}
+
+.language-css .token 
+{
+  color: var(--pink);
+}
+
+.token.script
+{
+  color: var(--foreground);
+}
+
+.token.bold 
+{
+  font-weight: bold;
+}
+
+.token.italic 
+{
+  font-style: italic;
+}
+
+.token.atrule, .token.attr-name, .token.attr-value 
+{
+  color: var(--green);
+}
+
+.language-css .token.atrule 
+{
+  color: var(--purple);
+}
+
+.language-html .token.attr-value, .language-markup .token.attr-value 
+{
+  color: var(--yellow);
+}
+
+.token.boolean 
+{
+  color: var(--purple);
+}
+
+.token.builtin, .token.class-name 
+{
+  color: var(--cyan);
+}
+
+.token.comment 
+{
+  color: var(--comment);
+}
+
+.token.constant 
+{
+  color: var(--purple);
+}
+
+.language-javascript .token.constant 
+{
+  color: var(--orange);
+  font-style: italic;
+}
+
+.token.entity 
+{
+  color: var(--pink);
+}
+
+.language-css .token.entity 
+{
+  color: var(--green);
+}
+
+.language-html .token.entity.named-entity
+{
+  color: var(--purple);
+}
+
+.language-html .token.entity:not(.named-entity) 
+{
+  color: var(--pink);
+}
+
+.language-markup .token.entity.named-entity
+{
+  color: var(--purple);
+}
+
+.language-markup .token.entity:not(.named-entity) 
+{
+  color: var(--pink);
+}
+
+.token.function 
+{
+  color: var(--green);
+}
+
+.language-css .token.function 
+{
+  color: var(--cyan);
+}
+
+.token.important, .token.keyword 
+{
+  color: var(--pink);
+}
+
+.token.prolog 
+{
+  color: var(--foreground);
+}
+
+.token.property 
+{
+  color: var(--orange);
+}
+
+.language-css .token.property 
+{
+  color: var(--cyan);
+}
+
+.token.punctuation 
+{
+  color: var(--pink);
+}
+
+.language-css .token.punctuation
+{
+  color: var(--orange);
+}
+
+.language-html .token.punctuation, .language-markup .token.punctuation 
+{
+  color: var(--foreground);
+}
+
+.token.selector 
+{
+  color: var(--pink);
+}
+
+.language-css .token.selector 
+{
+  color: var(--green);
+}
+
+.token.regex 
+{
+  color: var(--red);
+}
+
+.language-css .token.rule:not(.atrule)
+{
+  color: var(--foreground);
+}
+
+.token.string 
+{
+  color: var(--yellow);
+}
+
+.token.tag 
+{
+  color: var(--pink);
+}
+
+.token.url 
+{
+  color: var(--cyan);
+}
+
+.language-css .token.url 
+{
+  color: var(--orange);
+}
+
+.token.variable 
+{
+  color: var(--comment);
+}
+
+.token.number 
+{
+  color: rgba(189, 147, 249, 1);
+}
+
+.token.operator 
+{
+  color: rgba(139, 233, 253, 1);
+}
+
+.token.char 
+{
+  color: rgba(255, 135, 157, 1);
+}
+
+.token.symbol 
+{
+  color: rgba(255, 184, 108, 1);
+}
+
+.token.deleted 
+{
+  color: #e2777a;
+}
+
+.token.namespace 
+{
+  color: #e2777a;
+}
+
+/* Line Highlighter */
+
+.highlight-line
+{
+  color: inherit;
+  display: inline-block;
+  text-decoration: none;
+
+  border-radius: 4px;
+  padding: 2px 10px;
+}
+
+.highlight-line:empty:before
+{
+  content: " ";
+}
+
+.highlight-line:not(:last-child)
+{
+  min-width: 100%;
+}
+
+.highlight-line .highlight-line:not(:last-child)
+{
+  min-width: 0;
+}
+
+.highlight-line-isdir
+{
+  color: var(--foreground);
+  background-color: var(--selection-30);
+}
+
+.highlight-line-active
+{
+  background-color: var(--comment-30);
+}
+
+.highlight-line-add
+{
+  background-color: var(--green-30);
+}
+
+.highlight-line-remove
+{
+  background-color: var(--red-30);
+}
+ 


### PR DESCRIPTION
Adds `/collab-api` endpoint to SureSheets. It showcases the use of the simulation API.

It has some shortcomings compared to [Figma](https://www.figma.com/file/1PUMRYDVOzOsDu7hNofqfF/SureSheet?node-id=295%3A8812&t=nISokHVuYucwDuBe-1), but I think it's good enough to start with, if I'll have time I'll try to get it closer to the design.

Testing:
- `npm install` (even if you did that before) to install `prismjs` and other dependencies
- `npm run dev`
- visit http://localhost:3000/collab-api

To retest whole SureSheet platform, you first need to set up Sheets (`.env` file) and MongoDB replica (`docker compose up -d` and then `npx prisma generate && npx prisma db-push`)